### PR TITLE
Seezn 라이브 채널 지원

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -50,6 +50,11 @@ class Logic(object):
         'tving_vod_page' : '5',
         'tving_include_drm' : 'False',
 
+        'use_seezn' : 'False',
+        'seezn_quality' : 'HD',
+        'seezn_include_drm': 'False',
+        'seezn_cookie': '',
+
         'use_videoportal' : 'True',
 
         'use_everyon' : 'True',

--- a/logic.py
+++ b/logic.py
@@ -55,6 +55,8 @@ class Logic(object):
         'seezn_include_drm': 'False',
         'seezn_cookie': '',
         'seezn_adult': 'False',
+        'seezn_use_proxy': 'False',
+        'seezn_proxy_url': '',
 
         'use_videoportal' : 'True',
 

--- a/logic.py
+++ b/logic.py
@@ -54,6 +54,7 @@ class Logic(object):
         'seezn_quality' : 'HD',
         'seezn_include_drm': 'False',
         'seezn_cookie': '',
+        'seezn_adult': 'False',
 
         'use_videoportal' : 'True',
 

--- a/logic.py
+++ b/logic.py
@@ -51,7 +51,7 @@ class Logic(object):
         'tving_include_drm' : 'False',
 
         'use_seezn' : 'False',
-        'seezn_quality' : 'HD',
+        'seezn_quality' : 'FHD',
         'seezn_include_drm': 'False',
         'seezn_cookie': '',
         'seezn_adult': 'False',

--- a/logic_klive.py
+++ b/logic_klive.py
@@ -31,6 +31,7 @@ from .plugin import logger, package_name
 from .model import ModelSetting, ModelChannel, ModelCustom
 from .source_wavve import SourceWavve
 from .source_tving import SourceTving
+from .source_seezn import SourceSeezn
 from .source_videoportal import SourceVideoportal
 from .source_everyon import SourceEveryon
 from .source_streamlink import SourceStreamlink
@@ -76,6 +77,8 @@ class LogicKlive(object):
                 LogicKlive.source_list['tving'] = SourceTving('tving', ModelSetting.get('tving_id'), ModelSetting.get('tving_pw'), '0')
             if ModelSetting.get_bool('use_videoportal'):
                 LogicKlive.source_list['videoportal'] = SourceVideoportal('videoportal', None, None, None)
+            if ModelSetting.get_bool('use_seezn'):
+                LogicKlive.source_list['seezn'] = SourceSeezn('seezn', None, None, None)
             #if ModelSetting.get_bool('use_everyon'):
             #    LogicKlive.source_list['everyon'] = SourceEveryon('everyon', None, None, None)
             if ModelSetting.get_bool('use_kbs'):
@@ -136,7 +139,7 @@ class LogicKlive(object):
             arg = Util.db_list_to_dict(setting_list)
             for x in total_channel_list:
                 #if (arg['use_wavve'] == 'True' and x.wavve_id is not None) or (arg['use_tving'] == 'True' and x.tving_id is not None) or (arg['use_videoportal'] == 'True' and x.videoportal_id is not None) or (arg['use_everyon'] == 'True' and x.everyon_id is not None):
-                if (arg['use_wavve'] == 'True' and x.wavve_id is not None) or (arg['use_tving'] == 'True' and x.tving_id is not None) or (arg['use_videoportal'] == 'True' and x.videoportal_id is not None):
+                if (arg['use_wavve'] == 'True' and x.wavve_id is not None) or (arg['use_tving'] == 'True' and x.tving_id is not None) or (arg['use_videoportal'] == 'True' and x.videoportal_id is not None) or (arg['use_seezn'] == 'True' and x.seezn_id is not None):
                     tmp.append(x)
             
             # 이 목록에 없는 방송은 넣는다.. 스포츠, 라디오?
@@ -150,7 +153,7 @@ class LogicKlive(object):
                 for t in tmp2:
                     #logger.debug(t)
                     try:
-                        if (ch.source == 'wavve' and ch.source_id == t['wavve_id']) or (ch.source == 'tving' and ch.source_id == t['tving_id']) or (ch.source == 'videoportal' and ch.source_id == t['videoportal_id']) or (ch.source == 'everyon' and ch.source_id == t['everyon_id']):
+                        if (ch.source == 'wavve' and ch.source_id == t['wavve_id']) or (ch.source == 'tving' and ch.source_id == t['tving_id']) or (ch.source == 'videoportal' and ch.source_id == t['videoportal_id']) or (ch.source == 'seezn' and ch.source_id == t['seezn_id']): #or (ch.source == 'everyon' and ch.source_id == t['everyon_id']):
                             find = True
                             break
                     except:
@@ -164,9 +167,10 @@ class LogicKlive(object):
                     entity['wavve_name'] = entity['wavve_id'] = entity['wavve_number'] = None
                     entity['tving_name'] = entity['tving_id'] = entity['tving_number'] = None
                     entity['videoportal_name'] = entity['videoportal_id'] = entity['videoportal_number'] = None
+                    entity['seezn_name'] = entity['seezn_id'] = entity['seezn_number'] = None
                     entity['everyon_name'] = entity['everyon_id'] = entity['everyon_number'] = None
 
-                    if ch.source in ['wavve', 'tving', 'videoportal']:#, 'everyon']:
+                    if ch.source in ['wavve', 'tving', 'videoportal', 'seezn']:#, 'everyon']:
                         entity['%s_id' % ch.source] = ch.source_id
                         entity['%s_name' % ch.source] = ch.title
                         entity['category'] = ch.source
@@ -193,6 +197,8 @@ class LogicKlive(object):
                     x['auto'] = 'tving'
                 elif arg['use_videoportal'] == 'True' and x['videoportal_id'] is not None:
                     x['auto'] = 'videoportal'
+                elif arg['use_seezn'] == 'True' and x['seezn_id'] is not None:
+                    x['auto'] = 'seezn'
                 #elif arg['use_everyon'] == 'True' and x['everyon_id'] is not None:
                 #    x['auto'] = 'everyon'
 
@@ -208,6 +214,10 @@ class LogicKlive(object):
                     entity = db.session.query(ModelCustom).filter(ModelCustom.source == 'videoportal').filter(ModelCustom.source_id == x['videoportal_id']).first()
                     if entity is not None:
                         x['videoportal_number'] = entity.number
+                if x['seezn_id'] is not None:
+                    entity = db.session.query(ModelCustom).filter(ModelCustom.source == 'seezn').filter(ModelCustom.source_id == x['seezn_id']).first()
+                    if entity is not None:
+                        x['seezn_number'] = entity.number
                 #if x['everyon_id'] is not None:
                 #    entity = db.session.query(ModelCustom).filter(ModelCustom.source == 'everyon').filter(ModelCustom.source_id == x['everyon_id']).first()
                 #    if entity is not None:
@@ -233,6 +243,8 @@ class LogicKlive(object):
                     quality = ModelSetting.get('wavve_quality')
                 elif source == 'tving':
                     quality = ModelSetting.get('tving_quality')
+                elif source == 'seezn':
+                    quality = ModelSetting.get('seezn_quality')
             return LogicKlive.source_list[source].get_url(source_id, quality, mode)
         except Exception as e: 
             logger.error('Exception:%s', e)

--- a/plugin.py
+++ b/plugin.py
@@ -305,7 +305,7 @@ def api(sub):
             return data, 200, {'Content-Type':res.headers['Content-Type']}
             """
             headers = {'Connection' : 'keep-alive'}
-            r = requests.get(url, headers=headers, stream=True, proxies=proxies)
+            r = requests.get(url, headers=headers, stream=True, proxies=proxies, verify=False)
             rv = Response(r.iter_content(chunk_size=1024), r.status_code, content_type=r.headers['Content-Type'], direct_passthrough=True)
             return rv
 

--- a/source_seezn.py
+++ b/source_seezn.py
@@ -41,6 +41,10 @@ class SourceSeezn(SourceBase):
             ret = []
             data = requests.get('https://api.seezntv.com/svc/menu/app6/api/epg_chlist?category_id=1', headers=cls.default_header).json()
             for item in data['data']['list'][0]['list_channel']:
+                # 성인채널
+                if item['adult_yn'] == 'Y' and ModelSetting.get('seezn_adult') == 'False':
+                    continue
+
                 c = ModelChannel(cls.source_name, item['ch_no'], item['service_ch_name'], item['ch_image_list'], (item['type']!='AUDIO_MUSIC'))
                 if item['cj_drm_yn'] == 'Y':
                     c.is_drm_channel = True

--- a/source_seezn.py
+++ b/source_seezn.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#########################################################
+# python
+import os
+import sys
+import logging
+import traceback
+import json
+import re
+from datetime import datetime, timedelta
+import urllib
+
+# third-party
+import requests
+from flask import redirect
+
+# sjva 공용
+from framework import app, db, scheduler, path_app_root, path_data
+
+# 패키지
+from .plugin import logger, package_name
+from .model import ModelSetting, ModelChannel
+from .source_base import SourceBase
+
+#########################################################
+
+
+class SourceSeezn(SourceBase):
+    default_header = {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36',
+                'Accept': 'application/json',
+            }
+    
+    @classmethod
+    def prepare(cls, source_id, source_pw, arg):
+        pass
+
+    @classmethod
+    def get_channel_list(cls):
+        try:
+            ret = []
+            data = requests.get('https://api.seezntv.com/svc/menu/app6/api/epg_chlist?category_id=1', headers=cls.default_header).json()
+            for item in data['data']['list'][0]['list_channel']:
+                c = ModelChannel(cls.source_name, item['ch_no'], item['service_ch_name'], item['ch_image_list'], (item['type']!='AUDIO_MUSIC'))
+                if item['cj_drm_yn'] == 'Y':
+                    c.is_drm_channel = True
+
+                c.current = urllib.parse.unquote_plus(item['program_name'])
+                ret.append(c)
+            
+            
+        except Exception as e:
+            logger.error('Exception:%s', e)
+            logger.error(traceback.format_exc())
+        # logger.debug(ret)
+        return ret
+
+    @classmethod
+    def get_url(cls, source_id, quality, mode):
+        try:
+            qual = {'FHD': '4000', 'HD': '2000', 'SD': '1000'}
+            quality = qual[ModelSetting.get('seezn_quality')]
+            
+            # 오디오 채널은 고정일까? 매번 가져오는건 비효율..
+            # audio_ch = requests.get('https://api.seezntv.com/svc/menu/app6/api/epg_chlist?category_id=12&istest=0', headers=cls.default_header).json()['data']['list'][0]['list_channel']
+            # audio_chs = [ch['ch_no'] for ch in audio_ch]
+            audio_chs = ['701', '332', '718', '720', '716', '731', '729', '335', '733', '734', '732', '330', '333', '717', '730', '721', '722', '465', '466']
+            if source_id in audio_chs:
+                quality = '128'
+            
+            pre = ''
+            if len(ModelSetting.get('seezn_cookie')) < 1:
+                logger.debug('no cookie')
+                pre = 'pre'
+
+            live_url = f'https://api.seezntv.com/svc/menu/app6/api/epg_{pre}play?ch_no={source_id}&bit_rate=S&bit_rate_option={quality}&protocol=https&istest=0'
+            
+            header = {'x-omas-response-cookie': ModelSetting.get('seezn_cookie')}
+            ch_info = requests.get(live_url, headers=header).json()
+            if ch_info['meta']['code'] == '200':
+                url = ch_info['data']['live_url']
+            else:
+                logger.debug(ch_info['meta'])
+                pass
+                # live_url = ''
+
+            if mode == 'web_play':
+                return 'return_after_read', url
+            return 'redirect', url
+
+        except Exception as e:
+            logger.error('Exception:%s', e)
+            logger.error(traceback.format_exc())
+
+    @classmethod
+    def get_return_data(cls, source_id, url, mode):
+        try:
+            req_data = requests.get(url, verify=False, allow_redirects=False)
+            if req_data.status_code != 200:
+                redirect_url = req_data.headers['location']
+                data1 = requests.get(redirect_url, verify=False).text
+                data1 = re.sub('\w+.m3u8', redirect_url.split('.m3u8')[0]+'.m3u8', data1)
+                if mode == 'web_play':
+                    data1 = cls.change_redirect_data(data1)
+                return data1
+            else:
+                data1 = req_data.text
+                url2 = re.sub('\w+.m3u8', url.split('playlist.m3u8')[0]+'chunklist.m3u8', data1[data1.find('chunklist'):])
+                data2 = requests.get(url2).text
+                data3 = re.sub('media-', url2.split('chunklist.m3u8')[0]+'media-', data2)
+                if mode == 'web_play':
+                    data1 = cls.change_redirect_data(data3)
+                return data3
+            # logger.debug(url)
+            return url
+        except Exception as e:
+            logger.error('Exception:%s', e)
+            logger.error(traceback.format_exc())
+        return req_data.text

--- a/source_seezn.py
+++ b/source_seezn.py
@@ -55,6 +55,8 @@ class SourceSeezn(SourceBase):
                 # DRM 채널 여부
                 if item['cj_drm_yn'] == 'Y':
                     c.is_drm_channel = True
+                    if ModelSetting.get('seezn_include_drm') == 'False':
+                        continue
 
                 c.current = urllib.parse.unquote_plus(item['program_name'])
                 ret.append(c)

--- a/source_seezn.py
+++ b/source_seezn.py
@@ -87,6 +87,7 @@ class SourceSeezn(SourceBase):
             header = {'x-omas-response-cookie': ModelSetting.get('seezn_cookie')}
             
             # 시즌 프록시
+            # 재생 주소 가져올 때만 사용
             if ModelSetting.get('seezn_use_proxy') == 'True':
                 proxies = {'http': ModelSetting.get('seezn_proxy_url'), 'https': ModelSetting.get('seezn_proxy_url')}
             else:
@@ -104,6 +105,8 @@ class SourceSeezn(SourceBase):
 
             if mode == 'web_play':
                 return 'return_after_read', url
+            
+            # 해외 서버, 해외 클라이언트에서도 url만 가져오면 redirect로 재생 가능 확인
             return 'redirect', url
 
         except Exception as e:

--- a/source_seezn.py
+++ b/source_seezn.py
@@ -98,8 +98,7 @@ class SourceSeezn(SourceBase):
                 url = ch_info['data']['live_url']
             else:
                 # 재생권한 없음, 해외 IP 등등
-                logger.debug(ch_info['meta'])
-                pass
+                raise Exception(ch_info['meta'])
 
             if mode == 'web_play':
                 return 'return_after_read', url

--- a/templates/klive_custom_create.html
+++ b/templates/klive_custom_create.html
@@ -11,7 +11,11 @@
   {{ macros.m_col(2,  macros.m_strong('웨이브')) }}
   {{ macros.m_col(2,  macros.m_strong('티빙')) }}
   {{ macros.m_col(2,  macros.m_strong('비디오포털')) }}
+  {% if arg['use_seezn'] == 'True' %}
   {{ macros.m_col(2,  macros.m_strong('시즌')) }}
+  {% else %}
+  {{ macros.m_col(2) }}
+  {% endif %}
   {{ macros.m_col(2,  macros.m_strong('유저')) }}
   {{ macros.m_row_end() }}
   {{ macros.m_hr_head_bottom() }}

--- a/templates/klive_custom_create.html
+++ b/templates/klive_custom_create.html
@@ -11,7 +11,8 @@
   {{ macros.m_col(2,  macros.m_strong('웨이브')) }}
   {{ macros.m_col(2,  macros.m_strong('티빙')) }}
   {{ macros.m_col(2,  macros.m_strong('비디오포털')) }}
-  {{ macros.m_col(4,  macros.m_strong('유저')) }}
+  {{ macros.m_col(2,  macros.m_strong('시즌')) }}
+  {{ macros.m_col(2,  macros.m_strong('유저')) }}
   {{ macros.m_row_end() }}
   {{ macros.m_hr_head_bottom() }}
   <form id="custom_form" name="custom_form">
@@ -94,7 +95,7 @@ function make_list(ret, how) {
   //console.log(ret)
   str = '';
   data = ret.list
-  var site_use = [(ret.setting.use_wavve=='True'), (ret.setting.use_tving=='True'), (ret.setting.use_videoportal=='True'), (ret.setting.use_everyon=='True')];
+  var site_use = [(ret.setting.use_wavve=='True'), (ret.setting.use_tving=='True'), (ret.setting.use_videoportal=='True'), (ret.setting.use_seezn=='True'), (ret.setting.use_everyon=='True')];
   for (i in data) {
     //str += m_row_start_hover(0);
     str += m_row_start_hover();
@@ -108,14 +109,15 @@ function make_list(ret, how) {
       ['wavve', data[i].wavve_name, data[i].wavve_id, data[i].wavve_number],
       ['tving', data[i].tving_name, data[i].tving_id, data[i].tving_number],
       ['videoportal', data[i].videoportal_name, data[i].videoportal_id, data[i].videoportal_number],
+      ['seezn', data[i].seezn_name, data[i].seezn_id, data[i].seezn_number],
       ['user_source', data[i].user_source_name, data[i].user_source_id, data[i].user_source_number]
     ]
 
 
     for (j in site) {
-      if ((site[j][1] != null && site_use[j]) || (j == 3 && data[i].user_source != null)) {
+      if ((site[j][1] != null && site_use[j]) || (j == 4 && data[i].user_source != null)) {
         source_name = site[j][0]
-        if (j == 3) source_name = data[i].user_source
+        if (j == 4) source_name = data[i].user_source
         
         tmp_id = data[i].id + '|' + data[i].name+'|' + data[i].category + '|' + source_name +'|' + site[j][2] + '|' + site[j][1] + '|' + site[j][3]
         //console.log(tmp_id)

--- a/templates/klive_setting.html
+++ b/templates/klive_setting.html
@@ -9,6 +9,7 @@
     {{ macros.m_tab_head_start() }}
       {{ macros.m_tab_head2('wavve', '웨이브', true) }}
       {{ macros.m_tab_head2('tving', '티빙', false) }}
+      {{ macros.m_tab_head2('seezn', '시즌', false) }}
       {{ macros.m_tab_head2('ott_etc', '기타', false) }}
       {{ macros.m_tab_head2('youtubedl', 'Youtube-dl', false) }}
       {{ macros.m_tab_head2('streamlink', 'streamlink', false) }}
@@ -37,6 +38,19 @@
         {{ macros.setting_checkbox('tving_include_drm', 'DRM 채널 포함', value=arg['tving_include_drm'], desc=['On : OCN 등 DRM 채널 포함.']) }}
         {{ macros.m_hr() }}
         {{ macros.setting_input_int('tving_vod_page', 'VOD 탐색 페이지', value=arg['tving_vod_page'], min='1', desc=['최신 VOD 탐색 페이지 수']) }}
+      </div>
+    {{ macros.m_tab_content_end() }} 
+
+    {{ macros.m_tab_content_start('seezn', false) }}
+      {{ macros.setting_checkbox('use_seezn', 'seezn', value=arg['use_seezn'], desc=['계정 정보 없을 경우 3분간 재생', '유료계정 FHD 재생. OCN는 DRM채널 불가']) }}
+      <div id="use_seezn_div" class="collapse">
+        {{ macros.setting_select('seezn_quality', '시즌 화질', [['FHD','FHD'], ['HD','HD'], ['SD', 'SD']], col='3', value=arg['seezn_quality'])}}
+        {{ macros.setting_checkbox('seezn_include_drm', 'DRM 채널 포함', value=arg['seezn_include_drm'], desc=['On : OCN 등 DRM 채널 포함.']) }}
+        {{ macros.setting_input_text('seezn_cookie', 'cookie', value=arg['seezn_cookie'], desc=['SSOValidate=xxxx']) }}
+        {{ macros.m_hr() }}
+        <!--
+        {{ macros.setting_input_int('seezn_vod_page', 'VOD 탐색 페이지', value=arg['seezn_vod_page'], min='1', desc=['최신 VOD 탐색 페이지 수']) }}
+        -->
       </div>
     {{ macros.m_tab_content_end() }} 
 
@@ -117,6 +131,7 @@ var streamlink_installed = "{{ arg['tmp_is_streamlink_installed'] }}"  == 'Insta
 $(document).ready(function(){
   use_collapse("use_wavve")
   use_collapse("use_tving")
+  use_collapse("use_seezn")
   use_collapse("use_streamlink")
   use_collapse("use_youtubedl")
   use_collapse("use_navertv")
@@ -126,6 +141,7 @@ $(document).ready(function(){
 
 $('#use_wavve').change(function() {use_collapse('use_wavve');});
 $('#use_tving').change(function() {use_collapse('use_tving');});
+$('#use_seezn').change(function() {use_collapse('use_seezn');});
 $('#use_streamlink').change(function() {use_collapse('use_streamlink');});
 $('#use_youtubedl').change(function() {use_collapse('use_youtubedl');});
 $('#use_navertv').change(function() {use_collapse('use_navertv');});

--- a/templates/klive_setting.html
+++ b/templates/klive_setting.html
@@ -44,12 +44,12 @@
     {{ macros.m_tab_content_end() }} 
 
     {{ macros.m_tab_content_start('seezn', false) }}
-      {{ macros.setting_checkbox('use_seezn', 'seezn', value=arg['use_seezn'], desc=['계정 정보 없을 경우 3분간 재생', '유료계정 FHD 재생. OCN는 DRM채널 불가']) }}
+      {{ macros.setting_checkbox('use_seezn', 'seezn', value=arg['use_seezn'], desc=['계정 정보 없을 경우 3분간 재생', '유료/무료계정 FHD 재생.', '무료계정은 권한 있는 채널만 재생.']) }}
       <div id="use_seezn_div" class="collapse">
         {{ macros.setting_select('seezn_quality', '시즌 화질', [['FHD','FHD'], ['HD','HD'], ['SD', 'SD']], col='3', value=arg['seezn_quality'])}}
         {{ macros.setting_checkbox('seezn_include_drm', 'DRM 채널 포함', value=arg['seezn_include_drm'], desc=['On : OCN 등 DRM 채널 포함.']) }}
         {{ macros.setting_checkbox('seezn_adult', '성인 채널 포함', value=arg['seezn_adult'], desc=['On : 성인 채널 포함.']) }}
-        {{ macros.setting_input_text('seezn_cookie', 'cookie', value=arg['seezn_cookie'], desc=['SSOValidate=xxxx']) }}
+        {{ macros.setting_input_text('seezn_cookie', 'cookie', value=arg['seezn_cookie'], desc=['사이트 로그인 후 SSOValidate=xxxx 형태의 쿠키 입력.']) }}
         {{ macros.setting_checkbox('seezn_use_proxy', 'Proxy 사용', value=arg['seezn_use_proxy'], desc=['URL을 얻을 때만 사용합니다.']) }}
         <div id="seezn_use_proxy_div" class="collapse">
           {{ macros.setting_input_text('seezn_proxy_url', 'Proxy URL', value=arg['seezn_proxy_url'], desc=['']) }}

--- a/templates/klive_setting.html
+++ b/templates/klive_setting.html
@@ -9,7 +9,9 @@
     {{ macros.m_tab_head_start() }}
       {{ macros.m_tab_head2('wavve', '웨이브', true) }}
       {{ macros.m_tab_head2('tving', '티빙', false) }}
+      {% if arg['use_seezn'] == 'True' %}
       {{ macros.m_tab_head2('seezn', '시즌', false) }}
+      {% endif %}
       {{ macros.m_tab_head2('ott_etc', '기타', false) }}
       {{ macros.m_tab_head2('youtubedl', 'Youtube-dl', false) }}
       {{ macros.m_tab_head2('streamlink', 'streamlink', false) }}
@@ -46,11 +48,9 @@
       <div id="use_seezn_div" class="collapse">
         {{ macros.setting_select('seezn_quality', '시즌 화질', [['FHD','FHD'], ['HD','HD'], ['SD', 'SD']], col='3', value=arg['seezn_quality'])}}
         {{ macros.setting_checkbox('seezn_include_drm', 'DRM 채널 포함', value=arg['seezn_include_drm'], desc=['On : OCN 등 DRM 채널 포함.']) }}
+        {{ macros.setting_checkbox('seezn_adult', '성인 채널 포함', value=arg['seezn_adult'], desc=['On : 성인 채널 포함.']) }}
         {{ macros.setting_input_text('seezn_cookie', 'cookie', value=arg['seezn_cookie'], desc=['SSOValidate=xxxx']) }}
         {{ macros.m_hr() }}
-        <!--
-        {{ macros.setting_input_int('seezn_vod_page', 'VOD 탐색 페이지', value=arg['seezn_vod_page'], min='1', desc=['최신 VOD 탐색 페이지 수']) }}
-        -->
       </div>
     {{ macros.m_tab_content_end() }} 
 

--- a/templates/klive_setting.html
+++ b/templates/klive_setting.html
@@ -50,6 +50,10 @@
         {{ macros.setting_checkbox('seezn_include_drm', 'DRM 채널 포함', value=arg['seezn_include_drm'], desc=['On : OCN 등 DRM 채널 포함.']) }}
         {{ macros.setting_checkbox('seezn_adult', '성인 채널 포함', value=arg['seezn_adult'], desc=['On : 성인 채널 포함.']) }}
         {{ macros.setting_input_text('seezn_cookie', 'cookie', value=arg['seezn_cookie'], desc=['SSOValidate=xxxx']) }}
+        {{ macros.setting_checkbox('seezn_use_proxy', 'Proxy 사용', value=arg['seezn_use_proxy'], desc=['URL을 얻을 때만 사용합니다.']) }}
+        <div id="seezn_use_proxy_div" class="collapse">
+          {{ macros.setting_input_text('seezn_proxy_url', 'Proxy URL', value=arg['seezn_proxy_url'], desc=['']) }}
+        </div>
         {{ macros.m_hr() }}
       </div>
     {{ macros.m_tab_content_end() }} 
@@ -132,6 +136,7 @@ $(document).ready(function(){
   use_collapse("use_wavve")
   use_collapse("use_tving")
   use_collapse("use_seezn")
+  use_collapse("seezn_use_proxy")
   use_collapse("use_streamlink")
   use_collapse("use_youtubedl")
   use_collapse("use_navertv")
@@ -142,6 +147,7 @@ $(document).ready(function(){
 $('#use_wavve').change(function() {use_collapse('use_wavve');});
 $('#use_tving').change(function() {use_collapse('use_tving');});
 $('#use_seezn').change(function() {use_collapse('use_seezn');});
+$('#seezn_use_proxy').change(function() {use_collapse('seezn_use_proxy');});
 $('#use_streamlink').change(function() {use_collapse('use_streamlink');});
 $('#use_youtubedl').change(function() {use_collapse('use_youtubedl');});
 $('#use_navertv').change(function() {use_collapse('use_navertv');});


### PR DESCRIPTION
Seezn 라이브 채널 기능 지원입니다.

기본적으로 klive.db에서 `use_seezn` 값을 체크하여 `False`일 시에는 메뉴에서 숨겨지도록 하였고, sqlite 등을 통해 klive.db에 `use_seezn = "True"` 넣어주면 메뉴에 나타나도록 하였습니다.
쿠키 값을 넣어주지 않으면 미리보기 url로 연결하여 3분 재생되고, 사이트 로그인 후 `SSOValidate=xxxx` 형태의 쿠키 값을 입력하면 재생 권한이 있는 모든 채널 재생 가능합니다. 무료계정으로도 권한이 있는 채널은 FHD까지 재생 확인하였습니다.
성인 채널 4개는 노출 여부 설정할 수 있도록 설정에 옵션을 넣었습니다.
기타 다른 설정값은 기존 wavve나 tving 등과 동일하게 넣었고, DRM 재생 가능한 플레이어에서 OCN 재생되는 것 확인했습니다.
오라클 해외 리전에서 테스트 시, 재생 URL 가져오는 데에만 proxy 이용하면, url 얻고 난 이후에는 해외 서버, 해외 클라이언트에서 redirect로 재생 가능함 확인하였습니다.
url 가져올 때 https 인증서 불일치 문제가 있어 requests에 `verify=False` 옵션을 넣었습니다.

기타 기존 기능과 다른 부분은 주석 달아두었습니다.
custom 채널 생성 관련하여 epg.db에 채널 정보가 추가되면 동일 채널 소스별 구분 가능할 것 같습니다.

검토 부탁드립니다.
감사합니다.