### PR TITLE
시즌 Custom 채널 생성 시 DRM 채널 처리 관련 문제 수정

### DIFF
--- a/logic_klive.py
+++ b/logic_klive.py
@@ -305,6 +305,9 @@ class LogicKlive(object):
                     if mc.source == 'tving':
                         import framework.tving.api as Tving
                         mc.is_drm_channel = Tving.is_drm_channel(mc.source_id)
+                    if mc.source == 'seezn':
+                        # Seezn DRM 채널 추가 시 수정 필요
+                        mc.is_drm_channel = (mc.source_id in ['801'])
                     db.session.add(mc)
                     count += 1
             LogicKlive.reset_epg_time()


### PR DESCRIPTION
custom 생성 시에 DRM 채널을 제대로 처리하지 못하는 문제 수정하였습니다.
추후 OCN 이외의 DRM 채널이 추가되거나 채널번호가 변경된다면 수정이 필요합니다.